### PR TITLE
Little version cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,10 @@ else()
   )
 endif()
 
-if(${CMAKE_VERSION} VERSION_GREATER "3.1")
-  option(
-    USE_OPENMP
-    "Enable OpenMP to parallelize some of the algorithms. Note that this isn't always faster, see https://www.cryptopp.com/wiki/OpenMP"
-    OFF)
-endif()
+option(
+  USE_OPENMP
+  "Enable OpenMP to parallelize some of the algorithms. Note that this isn't always faster, see https://www.cryptopp.com/wiki/OpenMP"
+  OFF)
 
 # These are IA-32 options.
 option(DISABLE_ASM "Disable ASM" OFF)
@@ -140,21 +138,12 @@ endif()
 # ------------------------------------------------------------------------------
 
 # Declare project
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  project(${META_PROJECT_NAME} CXX C)
-  set(PROJECT_VERSION_MAJOR "${META_VERSION_MAJOR}")
-  set(PROJECT_VERSION_MINOR "${META_VERSION_MINOR}")
-  set(PROJECT_VERSION_PATCH"${META_VERSION_PATCH}")
-  set(PROJECT_VERSION "${LIB_VERSION_STRING}")
-else()
-  cmake_policy(SET CMP0048 NEW)
-  project(
-    ${META_PROJECT_NAME}
-    VERSION "${META_VERSION}"
-    DESCRIPTION "${META_PROJECT_DESCRIPTION}"
-    HOMEPAGE_URL "${META_GITHUB_REPO}"
-    LANGUAGES CXX C)
-endif()
+project(
+  ${META_PROJECT_NAME}
+  VERSION "${META_VERSION}"
+  DESCRIPTION "${META_PROJECT_DESCRIPTION}"
+  HOMEPAGE_URL "${META_GITHUB_REPO}"
+  LANGUAGES CXX C)
 
 # ---- Speedup build using ccache (needs CPM) ----
 include(cmake/FasterBuild.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMake basic options
 # ------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.12)
 
 # List of directories specifying a search path for CMake modules to be loaded by
 # the include() or find_package() commands before checking the default modules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMake basic options
 # ------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 
 # List of directories specifying a search path for CMake modules to be loaded by
 # the include() or find_package() commands before checking the default modules

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1109,7 +1109,7 @@ target_link_libraries(cryptopp ${CMAKE_THREAD_LIBS_INIT})
 # ============================================================================
 # Setup OpenMP
 # ============================================================================
-if(${CMAKE_VERSION} VERSION_GREATER "3.1" AND USE_OPENMP)
+if(USE_OPENMP)
   find_package(OpenMP)
 
   if(OPENMP_FOUND OR OPENMP_CXX_FOUND)
@@ -1171,8 +1171,7 @@ if(${CMAKE_VERSION} VERSION_GREATER "3.1" AND USE_OPENMP)
   if((NOT OPENMP_FOUND) AND (NOT OPENMP_CXX_FOUND))
     if((APPLE AND ((CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
                    OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")))
-       AND ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0")
-            AND (CMAKE_VERSION VERSION_LESS "3.12.0")))
+       AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0"))
       message(
         STATUS
           "OpenMP: Applying workaround for OSX OpenMP with old cmake that doesn't have FindOpenMP"

--- a/cryptopp/cryptoppConfig.cmake
+++ b/cryptopp/cryptoppConfig.cmake
@@ -7,7 +7,7 @@
 # and full source at https://github.com/alexreinking/SharedStaticStarter
 # ===-----------------------------------------------------------------------===#
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.12)
 
 set(cryptopp_known_comps static shared)
 set(cryptopp_comp_static NO)

--- a/test/integration/int-find-package/CMakeLists.txt
+++ b/test/integration/int-find-package/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12)
 
 # Test project for cryptopp-cmake installation
 project(CryptoppCmakeFindPackageTest)

--- a/test/integration/int-install-default/CMakeLists.txt
+++ b/test/integration/int-install-default/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12)
 
 # Test project for cryptopp-cmake installation
 project(CryptoppCmakeInstallDefaultTest)

--- a/test/integration/int-install-prefix/CMakeLists.txt
+++ b/test/integration/int-install-prefix/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12)
 
 # Test project for cryptopp-cmake installation
 project(CryptoppCmakeInstallPrefixTest)

--- a/test/unit/disable-feature/CMakeLists.txt
+++ b/test/unit/disable-feature/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12)
 
 # Test project for the standard way of using cryptopp-cmake
 project(CryptoppCmakeDisableFeatureTest)

--- a/test/unit/include-prefix/CMakeLists.txt
+++ b/test/unit/include-prefix/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12)
 
 # Test project for the standard way of using cryptopp-cmake
 project(CryptoppCmakeIncludePrefixTest)

--- a/test/unit/no-install/CMakeLists.txt
+++ b/test/unit/no-install/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12)
 
 # Test project for the standard way of using cryptopp-cmake
 project(CryptoppCmakeNoInstallTest)

--- a/test/unit/standard-cpm/CMakeLists.txt
+++ b/test/unit/standard-cpm/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12)
 
 # Test project for the standard way of using cryptopp-cmake
 project(CryptoppCmakeStandardTest)


### PR DESCRIPTION
I lowered the minimum version a bit and removed the version checks. As we require a higher version there's no need to carry compat-code for cmake 3.1 around. Also (not a separate commit) I removed the setting of the new policy, as new it will be set by cmake-minimum_required.

I think not limiting to an old version just to support old systems is a good idea, also I don't see a point in requiring the newest version without using the features it offers is not the best idea. That's why I lowered the version to the highest version it was checked for. If any newer feature is used, this should be adjusted to the needed version.

I also thought about including this as a var from one common file to ease changing of this value for all places, otoh it's maybe not required as the tests won't be generated if the configure failed. I'll leave this open to discussion as I can't check this atm.