### PR TITLE
Added Interface with CRYPTOPP_INSTALL_PREFIX definition and Added test for compilation with prefix

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1083,8 +1083,9 @@ set_target_properties(cryptopp PROPERTIES LINKER_LANGUAGE CXX)
 if(${CRYPTOPP_BUILD_SHARED})
   target_compile_definitions(cryptopp PRIVATE "CRYPTOPP_EXPORTS")
 endif()
-
-# TODO: make the prefix for includes settable (e.g. cryptopp, crypto++)
+target_compile_definitions(
+  cryptopp
+  INTERFACE $<INSTALL_INTERFACE:CRYPTOPP_INCLUDE_PREFIX=${CRYPTOPP_INCLUDE_PREFIX}>)
 cmake_path(GET CRYPTOPP_PROJECT_DIR PARENT_PATH CRYPTOPP_PREFIXED_INCLUDE_DIR)
 target_include_directories(
   cryptopp

--- a/test/example-src/main.cpp
+++ b/test/example-src/main.cpp
@@ -7,7 +7,12 @@
 #include <array>
 #include <cstdint>
 
+#ifdef CRYPTOPP_INCLUDE_PREFIX
+#define CRYPTOPP_HEADER(hdr)	<CRYPTOPP_INCLUDE_PREFIX/hdr>
+#include CRYPTOPP_HEADER(osrng.h)
+#else
 #include <cryptopp/osrng.h> // for random number generation
+#endif
 
 int main(int argc, char **argv) {
   constexpr size_t c_buffer_size = 16;


### PR DESCRIPTION
k, I now added the Interface and the code in the test to use it. This could also be the example you need for #9 (thanks to aMule). If I see this correct, the find-package test is run after all install tests, so it picks up the one with the prefix.

@abdes Have you an idea to reorder the tests so first all without and then all with prefix are run? Or do you think one test that uses the defined prefix from the interface is enough? Imho the code doesn't care about what is defined as long as a header is found, so testing this twice could be just dropped.