### PR TITLE
Change CRYPTOPP_SOURCES to a path variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ option(DISABLE_POWER9 "Disable POWER9" OFF)
 
 option(CRYPTOPP_USE_MASTER_BRANCH
        "Get crypto++ from the master branch, not from a release tag" FALSE)
-option(CRYPTOPP_SOURCES
+set(CRYPTOPP_SOURCES "" CACHE PATH
        "Use the provided location for crypto++ sources; do not fetch")
 option(CRYPTOPP_BUILD_TESTING "Build library tests" ON)
 option(CRYPTOPP_BUILD_DOCUMENTATION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,18 @@ else()
   )
 endif()
 
+if(CRYPTOPP_SOURCES)
+  set(CRYPTOPP_SOURCES
+      ${CRYPTOPP_SOURCES}
+      CACHE PATH
+            "Use the provided location for crypto++ sources; do not fetch")
+else()
+  set(CRYPTOPP_SOURCES
+      ""
+      CACHE PATH
+            "Use the provided location for crypto++ sources; do not fetch")
+endif()
+
 option(
   USE_OPENMP
   "Enable OpenMP to parallelize some of the algorithms. Note that this isn't always faster, see https://www.cryptopp.com/wiki/OpenMP"
@@ -105,8 +117,6 @@ option(DISABLE_POWER9 "Disable POWER9" OFF)
 
 option(CRYPTOPP_USE_MASTER_BRANCH
        "Get crypto++ from the master branch, not from a release tag" FALSE)
-set(CRYPTOPP_SOURCES "" CACHE PATH
-       "Use the provided location for crypto++ sources; do not fetch")
 option(CRYPTOPP_BUILD_TESTING "Build library tests" ON)
 option(CRYPTOPP_BUILD_DOCUMENTATION
        "Use Doxygen to create the HTML-based API documentation" OFF)


### PR DESCRIPTION
This changes `CRYPTOPP_SOURCES` from an option (which are intended only for [boolean values](https://cmake.org/cmake/help/latest/command/option.html)) to a path cache variable. The latter correctly translates backward-slash path separators on Windows to forward slashes. Previously, attempting to set this variable to a Windows-style path would result in errors like this:
```
CMake Error at cryptopp/CMakeLists.txt:1078 (add_library):
  Syntax error in cmake code when parsing string

    C:\Users\Admin\.conan\data\cryptopp\8.7.0\_\_\build\5a61a86bb3e07ce4262c80e1510f9c05e9b6d48b\src/zlib.cpp

  Invalid character escape '\U'.
```