### PR TITLE
Workaround invalid rdrand.asm output path (#13)

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -405,10 +405,12 @@ if(MSVC AND NOT DISABLE_ASM)
     enable_language(ASM_MASM)
     if(NOT DISABLE_RDRAND)
       list(APPEND cryptopp_SOURCES_ASM ${CRYPTOPP_PROJECT_DIR}/rdrand.asm)
-      # workaround https://github.com/abdes/cryptopp-cmake/issues/13
-      set_source_files_properties(${CRYPTOPP_PROJECT_DIR}/rdrand.asm
-                                  PROPERTIES COMPILE_OPTIONS
-                                             "/Fo\$(IntDir)rdrand.asm.obj")
+      if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
+        # workaround https://github.com/abdes/cryptopp-cmake/issues/13
+        set_source_files_properties(${CRYPTOPP_PROJECT_DIR}/rdrand.asm
+                                    PROPERTIES COMPILE_OPTIONS
+                                               "/Fo\$(IntDir)rdrand.asm.obj")
+      endif()
     endif()
     if(NOT DISABLE_RDSEED)
       list(APPEND cryptopp_SOURCES_ASM ${CRYPTOPP_PROJECT_DIR}/rdseed.asm)

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -405,6 +405,10 @@ if(MSVC AND NOT DISABLE_ASM)
     enable_language(ASM_MASM)
     if(NOT DISABLE_RDRAND)
       list(APPEND cryptopp_SOURCES_ASM ${CRYPTOPP_PROJECT_DIR}/rdrand.asm)
+      # workaround https://github.com/abdes/cryptopp-cmake/issues/13
+      set_source_files_properties(${CRYPTOPP_PROJECT_DIR}/rdrand.asm
+                                  PROPERTIES COMPILE_OPTIONS
+                                             "/Fo\$(IntDir)rdrand.asm.obj")
     endif()
     if(NOT DISABLE_RDSEED)
       list(APPEND cryptopp_SOURCES_ASM ${CRYPTOPP_PROJECT_DIR}/rdseed.asm)


### PR DESCRIPTION
This adds a workaround for the issue reported in #13 by overriding the object output path for `rdrand.asm`.
The workaround is only enabled when using Visual Studio as generator as Ninja is not affected.

According to a [comment on StackOverflow](https://stackoverflow.com/questions/61406734/how-to-change-the-object-file-name-through-a-cmakelists-txt#comment108633599_61406734), overriding the object output path via command-line options is not a good approach but it appears to work fine in my tests.

An alternative way to fix this would be to copy `rdrand.asm` to a different folder with a unique basename. I guess we don't want to directly rename the file since it would introduce working dir changes when the cryptopp repository is cloned. This approach would need a few more changes, that's why I went with the command-line override for now.

Closes #13