### PR TITLE
fix: workaround gcc-12 with -fno-devirtualize

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -35,6 +35,16 @@ jobs:
               generators: "Ninja",
             }
           - {
+              name: "ubuntu-22.04-gcc12",
+              os: ubuntu-22.04,
+              artifact: "Linux.7z",
+              build_type: "Release",
+              cc: "gcc-12",
+              cxx: "g++-12",
+              archiver: "7z a",
+              generators: "Ninja",
+            }
+          - {
               name: "macos-latest",
               os: macos-latest,
               artifact: "macOS.7z",
@@ -71,6 +81,14 @@ jobs:
         with:
           prepend_symlinks_to_path: false
           windows_compile_environment: msvc # this field is required
+
+      - name: Install gcc-12
+        shell: bash
+        if: endsWith(matrix.config.name, 'gcc12')
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-12 g++-12
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 110 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
 
       - name: Configure
         shell: cmake -P {0}

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -379,6 +379,18 @@ if(CRYPTOPP_SOLARIS)
 
 endif()
 
+# ------------------------------------------------------------------------------
+# https://github.com/abdes/cryptopp-cmake/issues/3
+#
+# If on Linux with GCC 12 or above, we need to add "-fno-devirtualize" flag to
+# workaround a specific issue introduced by gcc-12.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux"
+   AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12")
+  list(APPEND CRYPTOPP_COMPILE_OPTIONS "-fno-devirtualize")
+endif()
+# ------------------------------------------------------------------------------
+
 # ============================================================================
 # Sources & headers
 # ============================================================================


### PR DESCRIPTION
See #3 for more details. To be scheduled in next release of crypto++.

Check if:
* on Linux,
* AND using GNU compilers,
* AND compiler version >= 12

Then, add `-fno-devirtualize` as a compiler flag.

Also added a new matrix config for CI to build on Ubuntu-22.04 with GCC-12 to testthis change.
