### PR TITLE
test: fix find package test

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -65,10 +65,35 @@ jobs:
         with:
           cmake-version: 3.21.x
 
+      - name: Install ccache
+        shell: cmake -P {0}
+        run: |
+          if("${{ runner.os }}" STREQUAL "Windows")
+            # If ccache behaves badly on windows, skip this step
+            execute_process(COMMAND choco install ccache)
+          elseif("${{ runner.os }}" STREQUAL "macOS")
+            execute_process(COMMAND brew install ccache)
+          elseif("${{ runner.os }}" STREQUAL "Linux")
+            set(ccache_version "4.6.3")
+            set(ccache_dist "ccache-${ccache_version}-linux-x86_64")
+            set(ccache_url "https://github.com/ccache/ccache/releases/download/v${ccache_version}/${ccache_dist}.tar.xz")
+            file(DOWNLOAD "${ccache_url}" ./ccache.tar.xz SHOW_PROGRESS)
+            execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxvf ./ccache.tar.xz)
+            # Add to PATH environment variable
+            file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/${ccache_dist}" ccache_dir)
+            set(path_separator ":")
+            file(APPEND "$ENV{GITHUB_PATH}" "$ENV{GITHUB_WORKSPACE}${path_separator}${ccache_dir}")
+          else()
+            message(FATAL_ERROR, "${{ runner.os }} is not supported")
+          endif()
+
       - name: Setup ccache
-        if: runner.os != 'Windows'
+        # If ccache behaves badly on windows, skip this step
+        # if: runner.os != 'Windows'
         uses: Chocobo1/setup-ccache-action@v1
         with:
+          install_ccache: false
+          update_packager_index: false
           prepend_symlinks_to_path: false
           windows_compile_environment: msvc # this field is required
 
@@ -95,7 +120,15 @@ jobs:
           if ("${{ runner.os }}" STREQUAL "Windows")
             set(path_separator ";")
           endif()
+
           set(ENV{PATH} "$ENV{GITHUB_WORKSPACE}${path_separator}$ENV{PATH}")
+          # If ccache shows some strange behavior on windows, you can easily
+          # disable it here by setting the variable to "OFF"
+          if (NOT "${{ runner.os }}" STREQUAL "Windows")
+            set(enable_ccache "ON")
+          else()
+            set(enable_ccache "ON")
+          endif()
 
           execute_process(
             COMMAND cmake
@@ -104,6 +137,7 @@ jobs:
               -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
               -G Ninja
               -D CMAKE_MAKE_PROGRAM=ninja
+              -D USE_CCACHE=${enable_ccache}              
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ cmake_minimum_required(VERSION ${CRYPTOPP_MINIMUM_CMAKE_VERSION})
 # that come with CMake.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+# Setup our override file, in which we may cleanup cmake's default compiler
+# options, based on what we are doing.
+set(CMAKE_USER_MAKE_RULES_OVERRIDE "ResetInitialCompilerOptions")
+
 # ------------------------------------------------------------------------------
 # Project description and (meta) information
 # ------------------------------------------------------------------------------
@@ -76,13 +80,11 @@ endif()
 if(CRYPTOPP_SOURCES)
   set(CRYPTOPP_SOURCES
       ${CRYPTOPP_SOURCES}
-      CACHE PATH
-            "Use the provided location for crypto++ sources; do not fetch")
+      CACHE PATH "Use the provided location for crypto++ sources; do not fetch")
 else()
   set(CRYPTOPP_SOURCES
       ""
-      CACHE PATH
-            "Use the provided location for crypto++ sources; do not fetch")
+      CACHE PATH "Use the provided location for crypto++ sources; do not fetch")
 endif()
 
 option(

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,8 +18,7 @@
             },
             "cacheVariables": {
                 "CRYPTOPP_BUILD_TESTING": "ON",
-                "USE_CCACHE": "ON",
-                "CMAKE_USER_MAKE_RULES_OVERRIDE": "${sourceDir}/cmake/ResetInitialCompilerOptions.cmake"
+                "USE_CCACHE": "ON"
             }
         },
         {

--- a/cmake/ResetInitialCompilerOptions.cmake
+++ b/cmake/ResetInitialCompilerOptions.cmake
@@ -4,14 +4,31 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-if(MSVC)
+# This module is loaded by `cmake` while enabling support for each language from
+# either the project() or enable_language() commands. It is loaded after CMake's
+# builtin compiler and platform information modules have been loaded but before
+# the information is used. The file may set platform information variables to
+# override CMake's defaults.
+#
+# To load this module, set the variable `CMAKE_USER_MAKE_RULES_OVERRIDE` before
+# you declare the project or enable a language:
+# ~~~
+# set(CMAKE_USER_MAKE_RULES_OVERRIDE "ResetInitialCompilerOptions")
+# ~~~
+
+# We use this module to strip compiler options that are not really needed but
+# will cause compatibility issues with `ccache`.
+if(MSVC AND USE_CCACHE)
   # As of ccache 4.6, /Zi option automatically added by cmake is unsupported.
   # Given that we are doing ccache only in development environments (USE_CCACHE
   # controls if ccache is enabled), we can just strip that option.
-  if(${USE_CCACHE})
-    if(CMAKE_CXX_FLAGS_DEBUG_INIT MATCHES "/Zi")
-      string(REPLACE "/Zi" "" CMAKE_CXX_FLAGS_DEBUG_INIT
-                     ${CMAKE_CXX_FLAGS_DEBUG_INIT})
+  macro(strip_unwanted_options_from cmake_flags)
+    if(${cmake_flags} MATCHES "/Zi")
+      string(REPLACE "/Zi" "/Z7" ${cmake_flags} ${${cmake_flags}})
     endif()
-  endif()
+  endmacro()
+  strip_unwanted_options_from(CMAKE_CXX_FLAGS_DEBUG_INIT)
+  strip_unwanted_options_from(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT)
+  strip_unwanted_options_from(CMAKE_C_FLAGS_DEBUG_INIT)
+  strip_unwanted_options_from(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT)
 endif()

--- a/cryptopp/cryptoppConfig.cmake
+++ b/cryptopp/cryptoppConfig.cmake
@@ -35,8 +35,16 @@ set(cryptopp_static_targets
 set(cryptopp_shared_targets
     "${CMAKE_CURRENT_LIST_DIR}/cryptopp-shared-targets.cmake")
 
+message(
+  "^^^^^^^^^^^^^^^^^ cryptopp_static_targets = ${cryptopp_static_targets}")
+message(
+  "^^^^^^^^^^^^^^^^^ cryptopp_shared_targets = ${cryptopp_shared_targets}")
+
 macro(cryptopp_load_targets type)
   if(NOT EXISTS "${cryptopp_${type}_targets}")
+    message(
+      "^^^^^^^^^^^^^^^^^ NOT EXISTS cryptopp_${type}_targets : ${cryptopp_${type}_targets}"
+    )
     set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
         "cryptopp `${type}` libraries were requested but not found.")
     set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)

--- a/cryptopp/cryptoppConfig.cmake
+++ b/cryptopp/cryptoppConfig.cmake
@@ -35,16 +35,8 @@ set(cryptopp_static_targets
 set(cryptopp_shared_targets
     "${CMAKE_CURRENT_LIST_DIR}/cryptopp-shared-targets.cmake")
 
-message(
-  "^^^^^^^^^^^^^^^^^ cryptopp_static_targets = ${cryptopp_static_targets}")
-message(
-  "^^^^^^^^^^^^^^^^^ cryptopp_shared_targets = ${cryptopp_shared_targets}")
-
 macro(cryptopp_load_targets type)
   if(NOT EXISTS "${cryptopp_${type}_targets}")
-    message(
-      "^^^^^^^^^^^^^^^^^ NOT EXISTS cryptopp_${type}_targets : ${cryptopp_${type}_targets}"
-    )
     set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
         "cryptopp `${type}` libraries were requested but not found.")
     set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -88,7 +88,7 @@ add_test(
     # Enable verbose makefiles so we can see the full compile command line
     -D "CMAKE_VERBOSE_MAKEFILE=ON"
     # Throw the version in
-      -D CRYPTOPP_MINIMUM_CMAKE_VERSION=${CRYPTOPP_MINIMUM_CMAKE_VERSION})
+    -D CRYPTOPP_MINIMUM_CMAKE_VERSION=${CRYPTOPP_MINIMUM_CMAKE_VERSION})
 
 set_tests_properties(${test_name}-configure
                      PROPERTIES DEPENDS "int-install-default-install")
@@ -99,3 +99,6 @@ add_test(NAME ${test_name}-build
                  "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test")
 set_tests_properties(${test_name}-build PROPERTIES DEPENDS
                                                    ${test_name}-configure)
+
+set_tests_properties(int-install-prefix-configure
+                     PROPERTIES DEPENDS "int-find-package-build")

--- a/test/integration/int-find-package/CMakeLists.txt
+++ b/test/integration/int-find-package/CMakeLists.txt
@@ -9,6 +9,14 @@ cmake_minimum_required(VERSION ${CRYPTOPP_MINIMUM_CMAKE_VERSION})
 # Test project for cryptopp-cmake installation
 project(CryptoppCmakeFindPackageTest)
 
+message(
+  "---------------------- ${CRYPTOPP_CMAKE_INSTALL_ROOT} ----------------")
+file(GLOB_RECURSE contents "${CRYPTOPP_CMAKE_INSTALL_ROOT}/*cryptopp*")
+foreach(file ${contents})
+  message(${file})
+endforeach()
+
+message("--------------------------------------")
 find_package(cryptopp REQUIRED static PATHS ${CRYPTOPP_CMAKE_INSTALL_ROOT})
 
 # compile and link a test program using crypto++

--- a/test/integration/int-find-package/CMakeLists.txt
+++ b/test/integration/int-find-package/CMakeLists.txt
@@ -9,14 +9,10 @@ cmake_minimum_required(VERSION ${CRYPTOPP_MINIMUM_CMAKE_VERSION})
 # Test project for cryptopp-cmake installation
 project(CryptoppCmakeFindPackageTest)
 
-message(
-  "---------------------- ${CRYPTOPP_CMAKE_INSTALL_ROOT} ----------------")
-file(GLOB_RECURSE contents "${CRYPTOPP_CMAKE_INSTALL_ROOT}/*cryptopp*")
-foreach(file ${contents})
-  message(${file})
-endforeach()
-
-message("--------------------------------------")
+# Guide CMake to immediately find the package config exactly where we installed
+# before. Not doing this could (and it happened) result in CMake finding the
+# package config file in the source folder rather than in the install folder.
+set(cryptopp_ROOT ${CRYPTOPP_CMAKE_INSTALL_ROOT})
 find_package(cryptopp REQUIRED static PATHS ${CRYPTOPP_CMAKE_INSTALL_ROOT})
 
 # compile and link a test program using crypto++

--- a/test/integration/int-find-package/CMakeLists.txt
+++ b/test/integration/int-find-package/CMakeLists.txt
@@ -13,6 +13,9 @@ project(CryptoppCmakeFindPackageTest)
 # before. Not doing this could (and it happened) result in CMake finding the
 # package config file in the source folder rather than in the install folder.
 set(cryptopp_ROOT ${CRYPTOPP_CMAKE_INSTALL_ROOT})
+
+# Explicitly request the static library component to avoid cmake defaulting to
+# the shared component, which is currently not being built.
 find_package(cryptopp REQUIRED static PATHS ${CRYPTOPP_CMAKE_INSTALL_ROOT})
 
 # compile and link a test program using crypto++

--- a/test/integration/int-find-package/CMakeLists.txt
+++ b/test/integration/int-find-package/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION ${CRYPTOPP_MINIMUM_CMAKE_VERSION})
 # Test project for cryptopp-cmake installation
 project(CryptoppCmakeFindPackageTest)
 
-find_package(cryptopp REQUIRED PATHS ${CRYPTOPP_CMAKE_INSTALL_ROOT})
+find_package(cryptopp REQUIRED static PATHS ${CRYPTOPP_CMAKE_INSTALL_ROOT})
 
 # compile and link a test program using crypto++
 add_executable(rng-test ${TEST_EXAMPLE_SOURCES_DIR}/main.cpp)


### PR DESCRIPTION
The test was not robust enough. Now it specifically asks for the static version of `cryptopp` and guides `CMake` specifically to where we installed the package in the build folder.