### PR TITLE
fix: check_compile_link_option should use CRYPTOPP_COMPILE_DEFINITIONS

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -156,10 +156,13 @@ function(check_compile_link_option opt var prog)
   endif()
 
   message(STATUS "[cryptopp] Performing Test ${var}")
+  set(definitions ${CRYPTOPP_COMPILE_DEFINITIONS})
+  list(TRANSFORM definitions PREPEND "-D")
+  list(APPEND definitions ${opt})
   try_compile(
     COMMAND_SUCCESS ${CMAKE_BINARY_DIR}
     ${prog}
-    COMPILE_DEFINITIONS ${opt})
+    COMPILE_DEFINITIONS ${definitions})
   if(COMMAND_SUCCESS)
     set(${var}
         1


### PR DESCRIPTION
The test programs used in `check_compile_link_option` expect the already added definitions in previous tests to be made available. Therefore, the `CRYPTOPP_COMPILE_DEFINITIONS` should be passed to cmake's `try_compile`.