### PR TITLE
Fix Duplicate argument

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1122,6 +1122,8 @@ function(cryptopp_set_compile_properties)
       list(REMOVE_ITEM options ${global_flags})
     endif()
   endif()
+  list(REMOVE_DUPLICATES cryptopp_SOURCES)
+  list(REMOVE_DUPLICATES cryptopp_SOURCES_TEST)
   foreach(cxx_file ${cryptopp_SOURCES} ${cryptopp_SOURCES_TEST})
     set_property(
       SOURCE ${cxx_file}


### PR DESCRIPTION
``cmake ~/Development/cryptopp -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCRYPTOPP_COMPILE_OPTIONS="ANYTHING"`` will results in ANYTHING appended twice, at least on my current CRYPTOPP_8_7_0 tag