### PR TITLE
fix: Universal macOS build failing due to unquoted architectures string

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -185,7 +185,7 @@ function(check_target_architecture output pattern)
   include(TargetArch)
   target_architecture(target_arch)
   string(TOLOWER ${target_arch} target_arch)
-  if(${target_arch} MATCHES ${pattern})
+  if("${target_arch}" MATCHES ${pattern})
     message(
       STATUS
         "[cryptopp] Target architecture detected as: ${target_arch} -> ${output}"


### PR DESCRIPTION
When building a universal binary for macOS (i.e. ```CMAKE_OSX_ARCHITECTURES="x86_64;arm64"```), the architecture detect logic currently encounters the following error because ```${target_arch}``` is unquoted:

```
CMake Error at cryptopp-cmake/cryptopp/CMakeLists.txt:188 (if):
  if given arguments:

    "x86_64" "arm64" "MATCHES" "(x86_64|amd64)"

  Unknown arguments specified
Call Stack (most recent call first):
  cryptopp-cmake/cryptopp/CMakeLists.txt:214 (check_target_architecture)
```

This PR adds quotes so that multiple returned architectures won't cause a CMake error.