### PR TITLE
fix: Android build for armv7-a platform (#45)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ project(
   VERSION "${META_VERSION}"
   DESCRIPTION "${META_PROJECT_DESCRIPTION}"
   HOMEPAGE_URL "${META_GITHUB_REPO}"
-  LANGUAGES CXX C)
+  LANGUAGES CXX C ASM)
 
 # ---- Speedup build using ccache (needs CPM) ----
 include(cmake/FasterBuild.cmake)

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -659,7 +659,7 @@ endif()
 # Limit to Linux. The source files target the GNU assembler. Also see
 # https://www.cryptopp.com/wiki/Cryptogams.
 if(CRYPTOPP_ARM32
-   AND CMAKE_SYSTEM_NAME STREQUAL "Linux"
+   AND (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR ANDROID)
    AND NOT CRYPTOPP_DISABLE_ARM_NEON
    AND NOT CRYPTOPP_DISABLE_ASM)
   list(


### PR DESCRIPTION
1. Forgot about Android is also linux and trigger preprocessor around `config_asm.h:377`
2. Forgot to enable ASM and it leads to next errors:
```
  CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
  Missing variable is:
  CMAKE_ASM_COMPILE_OBJECT
```

According to cmake docs `ANDROID` variable introduced since Cmake 3.7

Closes #45