### PR TITLE
Libomp second part

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -65,6 +65,16 @@ jobs:
               generators: "Ninja",
             }
 
+          - {
+              name: "macos-latest-omp-macports",
+              os: macos-latest,
+              artifact: "macOS.7z",
+              build_type: "Release",
+              cc: "clang",
+              cxx: "clang++",
+              archiver: "7za a",
+              generators: "Ninja",
+            }
     steps:
       - uses: actions/checkout@v3
         with:
@@ -131,6 +141,14 @@ jobs:
           tools: libomp
         if: endsWith(matrix.config.name, 'homebrew')
 
+      - name: Install macports
+        uses: melusina-org/gha-install-macports@v1
+        if: endsWith(matrix.config.name, 'macports')
+
+      - name: Install libomp (macports)
+        run: port install libomp
+        if: endsWith(matrix.config.name, 'macports')
+
       - name: Configure
         shell: cmake -P {0}
         run: |
@@ -164,7 +182,7 @@ jobs:
             set(enable_ccache "ON")
           endif()
 
-          if ("${{ matrix.config.name }}" STREQUAL "macos-latest-omp-homebrew")
+          if ("${{ matrix.config.name }}" STREQUAL "macos-latest-omp-homebrew" OR "${{ matrix.config.name }}" STREQUAL "macos-latest-omp-macports")
             set(OMP "ON")
           else()
             set(OMP "OFF")

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1218,47 +1218,6 @@ if(USE_OPENMP)
   list (APPEND CMAKE_PREFIX_PATH /opt/local/lib/libomp/)
   list (APPEND CMAKE_INCLUDE_PATH /opt/local/include/libomp/)
   find_package(OpenMP REQUIRED)
-
-  set(Additional_OpenMP_Libraries_Workaround "")
-
-  # Workaround because older cmake on apple doesn't support FindOpenMP
-  if((NOT OPENMP_FOUND) AND (NOT OPENMP_CXX_FOUND))
-    if((APPLE AND ((CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-                   OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")))
-       AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0"))
-      message(
-        STATUS
-          "OpenMP: Applying workaround for OSX OpenMP with old cmake that doesn't have FindOpenMP"
-      )
-      set(OpenMP_CXX_FLAGS "-Xclang -fopenmp")
-      set(Additional_OpenMP_Libraries_Workaround "-lomp")
-    else()
-      message(
-        FATAL_ERROR
-          "OpenMP: Did not find OpenMP. Build without USE_OPENMP if you want to allow this."
-      )
-    endif()
-  endif()
-
-  if(NOT TARGET OpenMP::OpenMP_CXX)
-    # We're on cmake < 3.9, handle behavior of the old FindOpenMP implementation
-    message(
-      STATUS
-        "OpenMP: Applying workaround for old CMake that doesn't define FindOpenMP using targets"
-    )
-    add_library(OpenMP_TARGET INTERFACE)
-    add_library(OpenMP::OpenMP_CXX ALIAS OpenMP_TARGET)
-    target_compile_options(OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS}
-    )# add to all targets depending on this
-    find_package(Threads REQUIRED)
-    target_link_libraries(OpenMP_TARGET INTERFACE Threads::Threads)
-    target_link_libraries(
-      OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS}
-                              ${Additional_OpenMP_Libraries_Workaround})
-  endif()
-  # Workaround for Ubuntu 18.04 that otherwise doesn't set -fopenmp for linking
-  target_link_libraries(cryptopp ${OpenMP_CXX_FLAGS})
-  target_link_libraries(cryptopp OpenMP::OpenMP_CXX)
 endif()
 
 # ============================================================================

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1215,37 +1215,12 @@ target_link_libraries(cryptopp ${CMAKE_THREAD_LIBS_INIT})
 if(USE_OPENMP)
   list (APPEND CMAKE_PREFIX_PATH /usr/local/opt/libomp)
   list (APPEND CMAKE_PREFIX_PATH /opt/homebrew/opt/libomp/)
+  list (APPEND CMAKE_PREFIX_PATH /opt/local/lib/libomp/)
+  list (APPEND CMAKE_INCLUDE_PATH /opt/local/include/libomp/)
   find_package(OpenMP)
 
   if(OPENMP_FOUND OR OPENMP_CXX_FOUND)
     message(STATUS "[cryptopp] OpenMP: Found libomp without any special flags")
-  endif()
-
-  # If OpenMP wasn't found, try if we can find it in the default Macports
-  # location
-  if((NOT OPENMP_FOUND)
-     AND (NOT OPENMP_CXX_FOUND)
-     AND EXISTS "/opt/local/lib/libomp/libomp.dylib") # older cmake uses
-                                                      # OPENMP_FOUND, newer
-                                                      # cmake also sets
-                                                      # OPENMP_CXX_FOUND,
-                                                      # homebrew installations
-                                                      # seem only to get the
-                                                      # latter set.
-    set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I/opt/local/include/libomp/")
-    set(OpenMP_CXX_LIB_NAMES omp)
-    set(OpenMP_omp_LIBRARY /opt/local/lib/libomp/libomp.dylib)
-
-    find_package(OpenMP)
-    if(OPENMP_FOUND OR OPENMP_CXX_FOUND)
-      message(
-        STATUS "[cryptopp] OpenMP: Found libomp in macports default location.")
-    else()
-      message(
-        FATAL_ERROR
-          "OpenMP: Didn't find libomp. Tried macports default location but also didn't find it."
-      )
-    endif()
   endif()
 
   set(Additional_OpenMP_Libraries_Workaround "")

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1217,11 +1217,7 @@ if(USE_OPENMP)
   list (APPEND CMAKE_PREFIX_PATH /opt/homebrew/opt/libomp/)
   list (APPEND CMAKE_PREFIX_PATH /opt/local/lib/libomp/)
   list (APPEND CMAKE_INCLUDE_PATH /opt/local/include/libomp/)
-  find_package(OpenMP)
-
-  if(OPENMP_FOUND OR OPENMP_CXX_FOUND)
-    message(STATUS "[cryptopp] OpenMP: Found libomp without any special flags")
-  endif()
+  find_package(OpenMP REQUIRED)
 
   set(Additional_OpenMP_Libraries_Workaround "")
 


### PR DESCRIPTION
As promised around 4 month ago, I shortened the libomp detection for macports also.
Test for macports was added
The workarounds for creating the targets with older cmake was dropped.