### PR TITLE
fix: also set compiler env for the tests

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -262,8 +262,22 @@ jobs:
           # Do not run tests in parallel as we share things between them to
           # speed up the build and enable caching. The benefit of caching is
           # much higher than parallel tests.
-
+          set(ENV{CC} ${{ matrix.config.cc }})
+          set(ENV{CXX} ${{ matrix.config.cxx }})
           set(ENV{CTEST_OUTPUT_ON_FAILURE} "ON")
+
+          if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+            execute_process(
+              COMMAND "${{ matrix.config.environment_script }}" && set
+              OUTPUT_FILE environment_script_output.txt
+            )
+            file(STRINGS environment_script_output.txt output_lines)
+            foreach(line IN LISTS output_lines)
+              if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
+                set(ENV{${CMAKE_MATCH_1}} "${CMAKE_MATCH_2}")
+              endif()
+            endforeach()
+          endif()
 
           execute_process(
             COMMAND ctest "-E" "cryptest"


### PR DESCRIPTION
First things first:

While trying to separate the cygwin/mingw32 fixes I got absolutely confused. I'm not sure if the tests should be really run silent, as the problem was in the configure step but only the failing build was shown.

I don't know where the mingw env comes from, but it seems that the windows tests had always been run in mingw64 env. More confusing, the flags that cause this build-error aren't needed on pure mingw64 (which seems to be used judging from the path of the found compiler) so there seems to be something really messed up in this env.

I didn't delete the test runs, just in case you want some confusion, too.