### PR TITLE
Build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,30 @@ if(${CRYPTOPP_BUILD_SHARED})
   )
 endif()
 
+if (EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set (CRYPTOPP_DEFAULT_BUILD_TYPE "Debug")
+else()
+  set (CRYPTOPP_DEFAULT_BUILD_TYPE "Release")
+endif (EXISTS "${CMAKE_SOURCE_DIR}/.git")
+
+# Set the possible values of build type for cmake-gui
+if (CMAKE_CONFIGURATION_TYPES)
+  set (CMAKE_CONFIGURATION_TYPES "Debug;Release"
+       CACHE STRING
+       "Semicolon separated list of supported configuration types, only supports debug and release, anything else will be ignored"
+       FORCE)
+
+  set_property (CACHE CMAKE_CONFIGURATION_TYPES
+                PROPERTY STRINGS
+                "Debug" "Release")
+endif()
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message (STATUS "Setting build type to '${CRYPTOPP_DEFAULT_BUILD_TYPE}' as none was specified.")
+
+  set (CMAKE_BUILD_TYPE "${CRYPTOPP_DEFAULT_BUILD_TYPE}" CACHE STRING
+       "Choose the type of build." FORCE)
+endif()
 # ------------------------------------------------------------------------------
 # Project Declaration
 # ------------------------------------------------------------------------------

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1242,7 +1242,8 @@ if(CRYPTOPP_BUILD_TESTING)
        DESTINATION ${PROJECT_BINARY_DIR})
 
   add_test(NAME cryptopp-build_cryptest COMMAND "${CMAKE_COMMAND}" --build
-                                       ${CMAKE_BINARY_DIR} --target cryptest)
+                                       ${CMAKE_BINARY_DIR} --target cryptest
+                                       --config ${CMAKE_BUILD_TYPE})
   add_test(
     NAME cryptopp-cryptest
     COMMAND $<TARGET_FILE:cryptest> v

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -39,12 +39,15 @@ foreach(test ${tests})
       # Enable verbose makefiles so we can see the full compile command line
       -D "CMAKE_VERBOSE_MAKEFILE=ON"
       # Throw the version in
-      -D CRYPTOPP_MINIMUM_CMAKE_VERSION=${CRYPTOPP_MINIMUM_CMAKE_VERSION})
+      -D CRYPTOPP_MINIMUM_CMAKE_VERSION=${CRYPTOPP_MINIMUM_CMAKE_VERSION}
+      # Set the build-type to what we are building
+      -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
   # Build
   add_test(NAME cryptopp-${test_name}-build
            COMMAND ${CMAKE_COMMAND} --build
-                   "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test")
+                   "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test"
+                   --config ${CMAKE_BUILD_TYPE})
   set_tests_properties(cryptopp-${test_name}-build PROPERTIES DEPENDS
                                                      cryptopp-${test_name}-configure)
 
@@ -52,7 +55,8 @@ foreach(test ${tests})
   add_test(
     NAME cryptopp-${test_name}-install
     COMMAND ${CMAKE_COMMAND} --build
-            "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test" --target install)
+            "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test" --target install
+            --config ${CMAKE_BUILD_TYPE})
   set_tests_properties(cryptopp-${test_name}-install PROPERTIES DEPENDS
                                                        cryptopp-${test_name}-build)
 
@@ -60,7 +64,8 @@ foreach(test ${tests})
   add_test(
     NAME cryptopp-${test_name}-checks
     COMMAND ${CMAKE_COMMAND} --build
-            "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test" --target do-checks)
+            "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test" --target do-checks
+            --config ${CMAKE_BUILD_TYPE})
   set_tests_properties(cryptopp-${test_name}-checks PROPERTIES DEPENDS
                                                       cryptopp-${test_name}-install)
 endforeach()
@@ -88,7 +93,9 @@ add_test(
     # Enable verbose makefiles so we can see the full compile command line
     -D "CMAKE_VERBOSE_MAKEFILE=ON"
     # Throw the version in
-    -D CRYPTOPP_MINIMUM_CMAKE_VERSION=${CRYPTOPP_MINIMUM_CMAKE_VERSION})
+    -D CRYPTOPP_MINIMUM_CMAKE_VERSION=${CRYPTOPP_MINIMUM_CMAKE_VERSION}
+    # Set the build-type to what we are building
+    -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
 set_tests_properties(cryptopp-${test_name}-configure
                      PROPERTIES DEPENDS "cryptopp-int-install-default-install")
@@ -96,7 +103,8 @@ set_tests_properties(cryptopp-${test_name}-configure
 # Build
 add_test(NAME cryptopp-${test_name}-build
          COMMAND ${CMAKE_COMMAND} --build
-                 "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test")
+                 "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test"
+                 --config ${CMAKE_BUILD_TYPE})
 set_tests_properties(cryptopp-${test_name}-build PROPERTIES DEPENDS
                                                    cryptopp-${test_name}-configure)
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -29,11 +29,14 @@ foreach(test ${tests})
       # Use local source code for cryptopp-cmake
       -D "CPM_cryptopp-cmake_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}/.."
       # Enable verbose makefiles so we can see the full compile command line
-      -D CMAKE_VERBOSE_MAKEFILE=ON)
+      -D CMAKE_VERBOSE_MAKEFILE=ON
+      # Set the build-type to what we are building
+      -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   # Build
   add_test(NAME cryptopp-${test_name}-build
            COMMAND ${CMAKE_COMMAND} --build
-                   "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test")
+                   "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test"
+                   --config ${CMAKE_BUILD_TYPE})
   # Run build test case after the configure test case
   set_tests_properties(cryptopp-${test_name}-build PROPERTIES DEPENDS
                                                      cryptopp-${test_name}-configure)


### PR DESCRIPTION
If the build-type is not given it will be set to a default-vaule. Default is Debug when building a git checkout, otherwise Release. I guess this is a good compromise.

Also limit the chooseable build-types to Debug or Release

And tell the tests which flavour get's built.