### PR TITLE
fix: reenable unit-tests

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-file(GLOB tests "${CMAKE_CURRENT_SOURCE_DIR}/unit/*")
+file(GLOB tests "${CMAKE_CURRENT_SOURCE_DIR}/*")
+list(REMOVE_ITEM tests "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
+
 foreach(test ${tests})
   cmake_path(GET test FILENAME test_name)
   message(STATUS "Adding unit test: ${test_name}")
@@ -27,7 +29,7 @@ foreach(test ${tests})
       # Setup cmake source/build dirs
       -S "${test}" -B "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test"
       # Use local source code for cryptopp-cmake
-      -D "CPM_cryptopp-cmake_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}/.."
+      -D "CPM_cryptopp-cmake_SOURCE=${cryptopp-cmake_SOURCE_DIR}"
       # Enable verbose makefiles so we can see the full compile command line
       -D CMAKE_VERBOSE_MAKEFILE=ON
       # Set the build-type to what we are building

--- a/test/unit/disable-feature/CMakeLists.txt
+++ b/test/unit/disable-feature/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/cmake_minimum_required.cmake)
+include(${CPM_cryptopp-cmake_SOURCE}/cmake/cmake_minimum_required.cmake)
 cmake_minimum_required(VERSION ${CRYPTOPP_MINIMUM_CMAKE_VERSION})
 
 # Test project for the standard way of using cryptopp-cmake

--- a/test/unit/include-prefix/CMakeLists.txt
+++ b/test/unit/include-prefix/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/cmake_minimum_required.cmake)
+include(${CPM_cryptopp-cmake_SOURCE}/cmake/cmake_minimum_required.cmake)
 cmake_minimum_required(VERSION ${CRYPTOPP_MINIMUM_CMAKE_VERSION})
 
 # Test project for the standard way of using cryptopp-cmake

--- a/test/unit/no-install/CMakeLists.txt
+++ b/test/unit/no-install/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/cmake_minimum_required.cmake)
+include(${CPM_cryptopp-cmake_SOURCE}/cmake/cmake_minimum_required.cmake)
 cmake_minimum_required(VERSION ${CRYPTOPP_MINIMUM_CMAKE_VERSION})
 
 # Test project for the standard way of using cryptopp-cmake

--- a/test/unit/standard-cpm/CMakeLists.txt
+++ b/test/unit/standard-cpm/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # ===-----------------------------------------------------------------------===#
 
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/cmake_minimum_required.cmake)
+include(${CPM_cryptopp-cmake_SOURCE}/cmake/cmake_minimum_required.cmake)
 cmake_minimum_required(VERSION ${CRYPTOPP_MINIMUM_CMAKE_VERSION})
 
 # Test project for the standard way of using cryptopp-cmake


### PR DESCRIPTION
the unit-tests didn't run as tests/unit/unit/ was searched for them and CMAKE_CURRENT_SOURCE_DIR/.. points to test/.
I guess this file was moved somewhen in the past.

The first commit of this one went accidentally into master, I changed the name given to project to cryptopp-cmake as the fetch-sources part also uses cryptopp and overwrites cryptopp_SOURCES and we can't reach the toplevel dir easy.