### PR TITLE
Test deps

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1249,11 +1249,13 @@ if(CRYPTOPP_BUILD_TESTING)
   add_test(NAME cryptopp-build_cryptest COMMAND "${CMAKE_COMMAND}" --build
                                        ${CMAKE_BINARY_DIR} --target cryptest
                                        --config ${CMAKE_BUILD_TYPE})
+  set_tests_properties(cryptopp-build_cryptest PROPERTIES FIXTURES_SETUP cryptest-build)
+
   add_test(
     NAME cryptopp-cryptest
     COMMAND $<TARGET_FILE:cryptest> v
     WORKING_DIRECTORY ${CRYPTOPP_PROJECT_DIR})
-  set_tests_properties(cryptopp-cryptest PROPERTIES DEPENDS cryptopp-build_cryptest)
+  set_tests_properties(cryptopp-cryptest PROPERTIES FIXTURES_REQUIRED cryptest-build)
 endif()
 
 # ============================================================================

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1249,13 +1249,17 @@ if(CRYPTOPP_BUILD_TESTING)
   add_test(NAME cryptopp-build_cryptest COMMAND "${CMAKE_COMMAND}" --build
                                        ${CMAKE_BINARY_DIR} --target cryptest
                                        --config ${CMAKE_BUILD_TYPE})
-  set_tests_properties(cryptopp-build_cryptest PROPERTIES FIXTURES_SETUP cryptest-build)
+  set_tests_properties(cryptopp-build_cryptest PROPERTIES
+                       FIXTURES_SETUP cryptest-build
+                       LABELS "cryptopp;cryptopp-cryptest")
 
   add_test(
     NAME cryptopp-cryptest
     COMMAND $<TARGET_FILE:cryptest> v
     WORKING_DIRECTORY ${CRYPTOPP_PROJECT_DIR})
-  set_tests_properties(cryptopp-cryptest PROPERTIES FIXTURES_REQUIRED cryptest-build)
+  set_tests_properties(cryptopp-cryptest PROPERTIES
+                       FIXTURES_REQUIRED cryptest-build
+                       LABELS "cryptopp;cryptopp-cryptest")
 endif()
 
 # ============================================================================

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -42,14 +42,17 @@ foreach(test ${tests})
       -D CRYPTOPP_MINIMUM_CMAKE_VERSION=${CRYPTOPP_MINIMUM_CMAKE_VERSION}
       # Set the build-type to what we are building
       -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+  set_tests_properties(cryptopp-${test_name}-configure PROPERTIES
+                       FIXTURES_SETUP ${test_name}-config)
 
   # Build
   add_test(NAME cryptopp-${test_name}-build
            COMMAND ${CMAKE_COMMAND} --build
                    "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test"
                    --config ${CMAKE_BUILD_TYPE})
-  set_tests_properties(cryptopp-${test_name}-build PROPERTIES DEPENDS
-                                                     cryptopp-${test_name}-configure)
+  set_tests_properties(cryptopp-${test_name}-build PROPERTIES
+                       FIXTURES_SETUP ${test_name}-build
+                       FIXTURES_REQUIRED ${test_name}-config)
 
   # Install
   add_test(
@@ -57,8 +60,9 @@ foreach(test ${tests})
     COMMAND ${CMAKE_COMMAND} --build
             "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test" --target install
             --config ${CMAKE_BUILD_TYPE})
-  set_tests_properties(cryptopp-${test_name}-install PROPERTIES DEPENDS
-                                                       cryptopp-${test_name}-build)
+  set_tests_properties(cryptopp-${test_name}-install PROPERTIES
+                       FIXTURES_SETUP ${test_name}-install
+                       FIXTURES_REQUIRED ${test_name}-build)
 
   # Check installed files
   add_test(
@@ -66,8 +70,8 @@ foreach(test ${tests})
     COMMAND ${CMAKE_COMMAND} --build
             "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test" --target do-checks
             --config ${CMAKE_BUILD_TYPE})
-  set_tests_properties(cryptopp-${test_name}-checks PROPERTIES DEPENDS
-                                                      cryptopp-${test_name}-install)
+  set_tests_properties(cryptopp-${test_name}-checks PROPERTIES
+                       FIXTURES_REQUIRED ${test_name}-install)
 endforeach()
 
 # ------------------------------------------------------------------------------
@@ -97,16 +101,17 @@ add_test(
     # Set the build-type to what we are building
     -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
-set_tests_properties(cryptopp-${test_name}-configure
-                     PROPERTIES DEPENDS "cryptopp-int-install-default-install")
+set_tests_properties(cryptopp-${test_name}-configure PROPERTIES
+                     FIXTURES_SETUP ${test_name}-config
+                     FIXTURES_REQUIRED "int-install-default-install")
 
 # Build
 add_test(NAME cryptopp-${test_name}-build
          COMMAND ${CMAKE_COMMAND} --build
                  "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test"
                  --config ${CMAKE_BUILD_TYPE})
-set_tests_properties(cryptopp-${test_name}-build PROPERTIES DEPENDS
-                                                   cryptopp-${test_name}-configure)
+set_tests_properties(cryptopp-${test_name}-build PROPERTIES
+                     FIXTURES_REQUIRED ${test_name}-config)
 
 set_tests_properties(cryptopp-int-install-prefix-configure
                      PROPERTIES DEPENDS "cryptopp-int-find-package-build")

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -112,6 +112,3 @@ add_test(NAME cryptopp-${test_name}-build
                  --config ${CMAKE_BUILD_TYPE})
 set_tests_properties(cryptopp-${test_name}-build PROPERTIES
                      FIXTURES_REQUIRED ${test_name}-config)
-
-set_tests_properties(cryptopp-int-install-prefix-configure
-                     PROPERTIES DEPENDS "cryptopp-int-find-package-build")

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -12,6 +12,8 @@ file(GLOB tests "${CMAKE_CURRENT_SOURCE_DIR}/int-install-*")
 foreach(test ${tests})
   cmake_path(GET test FILENAME test_name)
   message(STATUS "Adding install integration test: ${test_name}")
+  string (REPLACE "int-" "" short_name cryptopp-${test_name})
+
   # Configure
   add_test(
     NAME cryptopp-${test_name}-configure
@@ -43,7 +45,8 @@ foreach(test ${tests})
       # Set the build-type to what we are building
       -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   set_tests_properties(cryptopp-${test_name}-configure PROPERTIES
-                       FIXTURES_SETUP ${test_name}-config)
+                       FIXTURES_SETUP ${test_name}-config
+                       LABELS "cryptopp;cryptopp-integration-tests;${short_name}")
 
   # Build
   add_test(NAME cryptopp-${test_name}-build
@@ -52,7 +55,8 @@ foreach(test ${tests})
                    --config ${CMAKE_BUILD_TYPE})
   set_tests_properties(cryptopp-${test_name}-build PROPERTIES
                        FIXTURES_SETUP ${test_name}-build
-                       FIXTURES_REQUIRED ${test_name}-config)
+                       FIXTURES_REQUIRED ${test_name}-config
+                       LABELS "cryptopp;cryptopp-integration-tests;${short_name}")
 
   # Install
   add_test(
@@ -62,7 +66,8 @@ foreach(test ${tests})
             --config ${CMAKE_BUILD_TYPE})
   set_tests_properties(cryptopp-${test_name}-install PROPERTIES
                        FIXTURES_SETUP ${test_name}-install
-                       FIXTURES_REQUIRED ${test_name}-build)
+                       FIXTURES_REQUIRED ${test_name}-build
+                       LABELS "cryptopp;cryptopp-integration-tests;${short_name}")
 
   # Check installed files
   add_test(
@@ -71,7 +76,8 @@ foreach(test ${tests})
             "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test" --target do-checks
             --config ${CMAKE_BUILD_TYPE})
   set_tests_properties(cryptopp-${test_name}-checks PROPERTIES
-                       FIXTURES_REQUIRED ${test_name}-install)
+                       FIXTURES_REQUIRED ${test_name}-install
+                       LABELS "cryptopp;cryptopp-integration-tests;${short_name}")
 endforeach()
 
 # ------------------------------------------------------------------------------
@@ -103,7 +109,8 @@ add_test(
 
 set_tests_properties(cryptopp-${test_name}-configure PROPERTIES
                      FIXTURES_SETUP ${test_name}-config
-                     FIXTURES_REQUIRED "int-install-default-install")
+                     FIXTURES_REQUIRED "int-install-default-install"
+                     LABELS "cryptopp;cryptopp-find_package")
 
 # Build
 add_test(NAME cryptopp-${test_name}-build
@@ -111,4 +118,5 @@ add_test(NAME cryptopp-${test_name}-build
                  "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test"
                  --config ${CMAKE_BUILD_TYPE})
 set_tests_properties(cryptopp-${test_name}-build PROPERTIES
-                     FIXTURES_REQUIRED ${test_name}-config)
+                     FIXTURES_REQUIRED ${test_name}-config
+                     LABELS "cryptopp;cryptopp-find_package")

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -34,12 +34,14 @@ foreach(test ${tests})
       -D CMAKE_VERBOSE_MAKEFILE=ON
       # Set the build-type to what we are building
       -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+  set_tests_properties(cryptopp-${test_name}-configure PROPERTIES
+                       FIXTURES_SETUP ${test_name}-config)
   # Build
   add_test(NAME cryptopp-${test_name}-build
            COMMAND ${CMAKE_COMMAND} --build
                    "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-test"
                    --config ${CMAKE_BUILD_TYPE})
   # Run build test case after the configure test case
-  set_tests_properties(cryptopp-${test_name}-build PROPERTIES DEPENDS
-                                                     cryptopp-${test_name}-configure)
+  set_tests_properties(cryptopp-${test_name}-build PROPERTIES
+                       FIXTURES_REQUIRED ${test_name}-config)
 endforeach()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -35,7 +35,8 @@ foreach(test ${tests})
       # Set the build-type to what we are building
       -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   set_tests_properties(cryptopp-${test_name}-configure PROPERTIES
-                       FIXTURES_SETUP ${test_name}-config)
+                       FIXTURES_SETUP ${test_name}-config
+                       LABELS "cryptopp;cryptopp-unit-tests;cryptopp-${test_name}")
   # Build
   add_test(NAME cryptopp-${test_name}-build
            COMMAND ${CMAKE_COMMAND} --build
@@ -43,5 +44,6 @@ foreach(test ${tests})
                    --config ${CMAKE_BUILD_TYPE})
   # Run build test case after the configure test case
   set_tests_properties(cryptopp-${test_name}-build PROPERTIES
-                       FIXTURES_REQUIRED ${test_name}-config)
+                       FIXTURES_REQUIRED ${test_name}-config
+                       LABELS "cryptopp;cryptopp-unit-tests;cryptopp-${test_name}")
 endforeach()


### PR DESCRIPTION
Here is the foundation of running tests in parrallel.
Would it make sense to have a test that calls them all in their own dirs, just to make sure the deps are still correct in the future? ccache should be able to speed this up to a sane level.