### PR TITLE
Cpm fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ include(cmake/FasterBuild.cmake)
 # If CMake is invoked with an explicit option (CRYPTOPP_PROJECT_DIR), setting
 # the location for user-provided sources of crypto++, or if the automatic
 # download fails, we use that option value to find the sources.
+find_package(Git)
 
 if(NOT CRYPTOPP_SOURCES)
   include(GetCryptoppSources)
@@ -213,6 +214,16 @@ else()
     )
   endif()
 endif()
+
+if (Git_FOUND)
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+                  WORKING_DIRECTORY ${cryptopp-cmake_SOURCE_DIR}
+                  OUTPUT_VARIABLE cryptopp_GIT_BRANCH)
+  string(STRIP ${cryptopp_GIT_BRANCH} cryptopp_GIT_BRANCH)
+else()
+  set(cryptopp_GIT_BRANCH "master")
+endif()
+message(STATUS "Using branch ${cryptopp_GIT_BRANCH} for tests")
 
 # ------------------------------------------------------------------------------
 # Testing

--- a/cmake/GetCryptoppSources.cmake
+++ b/cmake/GetCryptoppSources.cmake
@@ -55,7 +55,6 @@ endmacro()
 function(get_cryptopp_sources)
   # If we have git on the system, prefer the basic git workflow, which is more
   # predictable and straightforward than the FetchContent.
-  find_package(Git QUIET)
   if(GIT_FOUND)
     use_gitclone()
   else()

--- a/test/unit/disable-feature/CMakeLists.txt
+++ b/test/unit/disable-feature/CMakeLists.txt
@@ -23,7 +23,7 @@ cpmaddpackage(
   GITHUB_REPOSITORY
   abdes/cryptopp-cmake
   VERSION
-  master
+  ${cryptopp_GIT_BRANCH}
   OPTIONS
   "CRYPTOPP_BUILD_TESTING OFF"
   "DISABLE_ASM ON"

--- a/test/unit/disable-feature/CMakeLists.txt
+++ b/test/unit/disable-feature/CMakeLists.txt
@@ -21,7 +21,7 @@ cpmaddpackage(
   NAME
   cryptopp-cmake
   GITHUB_REPOSITORY
-  noloader/cryptopp-cmake
+  abdes/cryptopp-cmake
   VERSION
   master
   OPTIONS

--- a/test/unit/include-prefix/CMakeLists.txt
+++ b/test/unit/include-prefix/CMakeLists.txt
@@ -23,7 +23,7 @@ cpmaddpackage(
   GITHUB_REPOSITORY
   abdes/cryptopp-cmake
   VERSION
-  master
+  ${cryptopp_GIT_BRANCH}
   OPTIONS
   "CRYPTOPP_BUILD_TESTING OFF"
   "CRYPTOPP_INCLUDE_PREFIX crypto++")

--- a/test/unit/include-prefix/CMakeLists.txt
+++ b/test/unit/include-prefix/CMakeLists.txt
@@ -21,7 +21,7 @@ cpmaddpackage(
   NAME
   cryptopp-cmake
   GITHUB_REPOSITORY
-  noloader/cryptopp-cmake
+  abdes/cryptopp-cmake
   VERSION
   master
   OPTIONS

--- a/test/unit/no-install/CMakeLists.txt
+++ b/test/unit/no-install/CMakeLists.txt
@@ -23,7 +23,7 @@ cpmaddpackage(
   GIT_REPOSITORY
   abdes/cryptopp-cmake
   GIT_TAG
-  master
+  ${cryptopp_GIT_BRANCH}
   OPTIONS
   "CRYPTOPP_BUILD_TESTING OFF"
   "CRYPTOPP_INSTALL OFF")

--- a/test/unit/no-install/CMakeLists.txt
+++ b/test/unit/no-install/CMakeLists.txt
@@ -21,7 +21,7 @@ cpmaddpackage(
   NAME
   cryptopp-cmake
   GIT_REPOSITORY
-  https://github.com./abdes/cryptopp-cmake
+  abdes/cryptopp-cmake
   GIT_TAG
   master
   OPTIONS

--- a/test/unit/standard-cpm/CMakeLists.txt
+++ b/test/unit/standard-cpm/CMakeLists.txt
@@ -23,7 +23,7 @@ cpmaddpackage(
   GIT_REPOSITORY
   abdes/cryptopp-cmake
   GIT_TAG
-  master
+  ${cryptopp_GIT_BRANCH}
   OPTIONS
   "CRYPTOPP_BUILD_TESTING OFF")
 

--- a/test/unit/standard-cpm/CMakeLists.txt
+++ b/test/unit/standard-cpm/CMakeLists.txt
@@ -21,7 +21,7 @@ cpmaddpackage(
   NAME
   cryptopp-cmake
   GIT_REPOSITORY
-  https://github.com./abdes/cryptopp-cmake
+  abdes/cryptopp-cmake
   GIT_TAG
   master
   OPTIONS


### PR DESCRIPTION
A little fix for the cpm modules, 2 of them still used the old repo and then they've been 50% just the repo-name and 50% the complete repo-url. This is now unified and up-to-date.

In addition I added a check for using the branch that is checked out, so the tests use the same codebase as the code they are testing.