### PR TITLE
chore: moved project upwards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,6 @@ if(NOT GIT_SHA1)
   set(GIT_REV "0")
 endif()
 
-# Meta information about the project
-# cmake-format: off
 set(META_PROJECT_NAME        "cryptopp-cmake")
 set(META_PROJECT_DESCRIPTION "Free C++ class library of cryptographic schemes")
 set(META_GITHUB_REPO         "https://github.com/weidai11/cryptopp")
@@ -43,16 +41,20 @@ set(META_VERSION_PATCH       "0")
 set(META_VERSION_REVISION    "${GIT_REV}")
 set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
 set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERSION_REVISION})")
+# ------------------------------------------------------------------------------
+# Project Declaration
+# ------------------------------------------------------------------------------
+
+# Declare project
+project("${META_PROJECT_NAME}"
+  VERSION "${META_VERSION}"
+  DESCRIPTION "${META_PROJECT_DESCRIPTION}"
+  HOMEPAGE_URL "${META_GITHUB_REPO}"
+  LANGUAGES CXX C ASM)
+
 # cmake-format: on
 
-string(MAKE_C_IDENTIFIER ${META_PROJECT_NAME} META_PROJECT_ID)
-string(TOUPPER ${META_PROJECT_ID} META_PROJECT_ID)
-
-# Set the CRYPTOPP_VERSION to be the same as what was downloaded with CPM,
-# FetchContent, git clone, etc...
-set(CRYPTOPP_VERSION ${META_VERSION})
-
-message("=> Project : ${META_NAME_VERSION}")
+message("=> Project : ${PROJECT_NAME} v${cryptopp-cmake_VERSION}")
 
 # ============================================================================
 # Settable options
@@ -170,17 +172,6 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set (CMAKE_BUILD_TYPE "${CRYPTOPP_DEFAULT_BUILD_TYPE}" CACHE STRING
        "Choose the type of build." FORCE)
 endif()
-# ------------------------------------------------------------------------------
-# Project Declaration
-# ------------------------------------------------------------------------------
-
-# Declare project
-project(
-  ${META_PROJECT_NAME}
-  VERSION "${META_VERSION}"
-  DESCRIPTION "${META_PROJECT_DESCRIPTION}"
-  HOMEPAGE_URL "${META_GITHUB_REPO}"
-  LANGUAGES CXX C ASM)
 
 # ---- Speedup build using ccache (needs CPM) ----
 include(cmake/FasterBuild.cmake)

--- a/cmake/GetCryptoppSources.cmake
+++ b/cmake/GetCryptoppSources.cmake
@@ -10,7 +10,7 @@ macro(use_gitclone)
   else()
     set(source_location
         GIT_TAG
-        "CRYPTOPP_${META_VERSION_MAJOR}_${META_VERSION_MINOR}_${META_VERSION_PATCH}"
+        "CRYPTOPP_${version_underscore}"
     )
   endif()
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_deps)
@@ -19,7 +19,7 @@ macro(use_gitclone)
     PROJECT_NAME
     "${CRYPTOPP_INCLUDE_PREFIX}"
     GIT_URL
-    ${META_GITHUB_REPO}
+    ${cryptopp-cmake_HOMEPAGE_URL}
     ${source_location}
     DIRECTORY
     ${CMAKE_CURRENT_BINARY_DIR}/_deps
@@ -39,7 +39,7 @@ macro(use_url_download)
     file(MAKE_DIRECTORY ${FETCHCONTENT_BASE_DIR})
     FetchContent_Populate(
       cryptopp
-      URL "${META_GITHUB_REPO}/releases/download/CRYPTOPP_${META_VERSION_MAJOR}_${META_VERSION_MINOR}_${META_VERSION_PATCH}/cryptopp${META_VERSION_MAJOR}${META_VERSION_MINOR}${META_VERSION_PATCH}.zip"
+      URL "${cryptopp-cmake_HOMEPAGE_URL}/releases/download/CRYPTOPP_${version_underscore}/cryptopp${cryptopp-cmake_VERSION_MAJOR}${cryptopp-cmake_VERSION_MINOR}${cryptopp-cmake_VERSION_PATCH}.zip"
       QUIET
       SOURCE_DIR
         ${FETCHCONTENT_BASE_DIR}/cryptopp-src/${CRYPTOPP_INCLUDE_PREFIX}
@@ -55,6 +55,7 @@ endmacro()
 function(get_cryptopp_sources)
   # If we have git on the system, prefer the basic git workflow, which is more
   # predictable and straightforward than the FetchContent.
+  set (version_underscore "${cryptopp-cmake_VERSION_MAJOR}_${cryptopp-cmake_VERSION_MINOR}_${cryptopp-cmake_VERSION_PATCH}")
   if(GIT_FOUND)
     use_gitclone()
   else()

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1181,8 +1181,8 @@ list(APPEND cryptopp_LIBRARY_SOURCES ${cryptopp_SOURCES})
 
 add_library(cryptopp ${cryptopp_LIBRARY_SOURCES})
 add_library(cryptopp::cryptopp ALIAS cryptopp)
-set_target_properties(cryptopp PROPERTIES VERSION ${META_VERSION}
-                                          SOVERSION ${META_VERSION_MAJOR})
+set_target_properties(cryptopp PROPERTIES VERSION ${cryptopp-cmake_VERSION}
+                                          SOVERSION ${cryptopp-cmake_VERSION_MAJOR})
 set_target_properties(cryptopp PROPERTIES LINKER_LANGUAGE CXX)
 if(${CRYPTOPP_BUILD_SHARED})
   target_compile_definitions(cryptopp PRIVATE "CRYPTOPP_EXPORTS")

--- a/cryptopp/config.pc.in
+++ b/cryptopp/config.pc.in
@@ -8,7 +8,7 @@ datadir=${prefix}/@CMAKE_INSTALL_DATAROOTDIR@/cryptopp
 Name: Crypto++
 URL: https://cryptopp.com/
 Description: Crypto++ cryptographic library (built with CMake)
-Version: @CRYPTOPP_VERSION@
+Version: @cryptopp-cmake_VERSION@
 
 Cflags: -I${includedir}
 Libs: -L${libdir} @MODULE_LINK_LIBS@


### PR DESCRIPTION
It was less to change than I thought, After seeing that the revision isn't used the gitrevision files have been dropped also, if we really need something from there, the git executable can be used directly to get this.

If the versionupdate script is really needed, someone has to adapt it to being able to use with the new versioning, or we drop it also, as changing some numbers isn't that hard. Also we could get this directly from git.