### PR TITLE
test: added cryptest tv all

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1260,6 +1260,14 @@ if(CRYPTOPP_BUILD_TESTING)
   set_tests_properties(cryptopp-cryptest PROPERTIES
                        FIXTURES_REQUIRED cryptest-build
                        LABELS "cryptopp;cryptopp-cryptest")
+
+  add_test(
+    NAME cryptopp-cryptest-extensive
+    COMMAND $<TARGET_FILE:cryptest> tv all
+    WORKING_DIRECTORY ${CRYPTOPP_PROJECT_DIR})
+  set_tests_properties(cryptopp-cryptest-extensive PROPERTIES
+                       FIXTURES_CLEANUP cryptest-build
+                       LABELS "cryptopp;cryptopp-cryptest")
 endif()
 
 # ============================================================================


### PR DESCRIPTION
Docs suggest run cryptest tv all after the usual cryptest. It seems that there is a run condition as 50% failed when running them parallel. I choose to set that test as cleanup for the normal one which means it will be run if the after the normal one, always. The other option would be to set a depend, but then the other one would be run always before this one. As fixtures are already in place, I guess this is the better option.