### PR TITLE
Cygwin

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -306,3 +306,53 @@ jobs:
       run:  ctest -j40 --verbose -R cryptest --test-dir build -C ${{ matrix.build-type }}
     - name: Run tests
       run: ctest -j40 -E cryptest --output-on-failure --test-dir build -C ${{ matrix.build-type }}
+
+  cygwin:
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [Release]
+        config:
+          - {
+              name: "with OMP ",
+              omp: ON,
+            }
+          - {
+              name: "",
+              omp: "OFF",
+            }
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: C:\cygwin\bin\bash.exe --login -o igncr '{0}'
+    name: Cygwin  ${{ matrix.config.name }}(${{ matrix.build-type }})
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Setup cygwin
+      uses: cygwin/cygwin-install-action@master
+      with:
+        packages: >-
+          ccache
+          cmake
+          gcc-core
+          gcc-g++
+          ninja
+    - name: Configure
+      run: |
+        cmake /cygdrive/d/a/cryptopp-cmake/cryptopp-cmake \
+          -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -G Ninja \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+          -DUSE_OPENMP=${{ matrix.config.omp }} \
+          -D USE_CCACHE=ON
+    - name: Build
+      run: cmake --build build --config ${{ matrix.build-type }}
+    - name: Run cryptest
+      run:  ctest -j40 --verbose -R cryptest --test-dir build -C ${{ matrix.build-type }}
+    - name: Run tests
+      run: ctest -j40 -E cryptest --output-on-failure --test-dir build -C ${{ matrix.build-type }}

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -208,6 +208,7 @@ message(
   STATUS "[cryptopp]      CMAKE_SYSTEM_PROCESSOR : ${CMAKE_SYSTEM_PROCESSOR}")
 
 check_target_architecture(CRYPTOPP_AMD64 "(x86_64|amd64)")
+check_target_architecture(CRYPTOPP_CYGWIN "cygwin")
 check_target_architecture(CRYPTOPP_I386 "^i.86$")
 check_target_architecture(CRYPTOPP_MINGW32 "^mingw32")
 check_target_architecture(CRYPTOPP_MINGW64 "(w64-mingw32|mingw64)")
@@ -227,11 +228,6 @@ endif()
 
 if(CRYPTOPP_PPC64)
   set(CRYPTOPP_PPC32 0)
-endif()
-
-if (CRYPTOPP_CYGWIN AND NOT CRYPTOPP_DISABLE_ASM)
-    message (STATUS "[cryptopp] Disabling ASM on Cygwin")
-    list(APPEND CRYPTOPP_COMPILE_DEFINITIONS "CRYPTOPP_DISABLE_ASM=1")
 endif()
 # ##############################################################################
 
@@ -409,7 +405,7 @@ include(sources)
 # X86/X32/X64 Options               #####
 # ##############################################################################
 
-if((CRYPTOPP_I386 OR CRYPTOPP_AMD64 OR CRYPTOPP_MINGW32 OR CRYPTOPP_MINGW64)
+if((CRYPTOPP_I386 OR CRYPTOPP_AMD64 OR CRYPTOPP_MINGW32 OR CRYPTOPP_MINGW64 OR CRYPTOPP_CYGWIN))
     AND NOT MSVC)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
     set(sse2_flag "-xarch=sse2")

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -405,7 +405,7 @@ include(sources)
 # X86/X32/X64 Options               #####
 # ##############################################################################
 
-if((CRYPTOPP_I386 OR CRYPTOPP_AMD64 OR CRYPTOPP_MINGW32 OR CRYPTOPP_MINGW64 OR CRYPTOPP_CYGWIN))
+if((CRYPTOPP_I386 OR CRYPTOPP_AMD64 OR CRYPTOPP_MINGW32 OR CRYPTOPP_MINGW64 OR CRYPTOPP_CYGWIN)
     AND NOT MSVC)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
     set(sse2_flag "-xarch=sse2")


### PR DESCRIPTION
The last missing part of the big PR is finished now. Ccache of Choco is not useable from within cygwin and the native one is old, it doesn't even speed up the tests. It would be possible to skip integration tests for now until it's sorted out, but as we're not having that much activity, it should be OK for now

Here again, debug segfaults cryptest. hopefully this will be sorted out somewhen in the future.