### PR TITLE
Fix USE_OPENMP

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1211,7 +1211,7 @@ target_link_libraries(cryptopp ${CMAKE_THREAD_LIBS_INIT})
 # ============================================================================
 # Setup OpenMP
 # ============================================================================
-if(USE_OPENMP)
+if(CRYPTOPP_USE_OPENMP)
   list (APPEND CMAKE_PREFIX_PATH /usr/local/opt/libomp)
   list (APPEND CMAKE_PREFIX_PATH /opt/homebrew/opt/libomp/)
   list (APPEND CMAKE_PREFIX_PATH /opt/local/lib/libomp/)


### PR DESCRIPTION
On top of https://github.com/abdes/cryptopp-cmake/commit/899542f1f7f0e55cfa1f41cfb3e9aa9dc157eace, this is also needed to make the OpenMP option work correctly