### PR TITLE
fix: undefined reference to CryptoPP::precomputedPrimeTable'

### DIFF
--- a/cryptopp/sources.cmake
+++ b/cryptopp/sources.cmake
@@ -117,6 +117,7 @@ set(cryptopp_SOURCES
     poly1305.cpp
     polynomi.cpp
     ppc_simd.cpp
+    primetab.cpp
     pssr.cpp
     pubkey.cpp
     queue.cpp


### PR DESCRIPTION
**Summary:** #88.
According to the change log, Primetab.cpp has been added to the [cryptopp](https://github.com/weidai11/cryptopp) repository at the end of the June: [6ecc789](https://github.com/weidai11/cryptopp/commit/6ecc789df1cea7640f54ddc2aed149c6b188891f). But the last update of [0f506cf](https://github.com/abdes/cryptopp-cmake/commit/0f506cf5584422e8af255db7e333dec6727a9a9e), used in **cryptopp-cmake** project, is dated May 26, and this list does not include Primetab.cpp.

**Bug:** 
The **cryptopp-cmake** project was used to run _cmake_ on a separate project. This repository was added recently as a submodule to a separate project which contains **cryptopp** from [](https://github.com/weidai11/cryptopp) as a _submodule_ as well. Performing _cmake --build ._, and during LINKING stage of programs the issue of  `undefined reference to `CryptoPP::precomputedPrimeTable'` occurred:
```
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: lib/libcryptopp.a(nbtheory.cpp.obj):nbtheory.cpp:(.rdata$.refptr._ZN8CryptoPP21precomputedPrimeTableE[.refptr._ZN8CryptoPP21precomputedPrimeTableE]+0x0): undefined reference to `CryptoPP::precomputedPrimeTable'
collect2.exe: error: ld returned 1 exit status
mingw32-make[2]: *** [CMakeFiles\aes256.dir\build.make:101: bin/aes256.exe] Error 1
mingw32-make[1]: *** [CMakeFiles\Makefile2:215: CMakeFiles/aes256.dir/all] Error 2
mingw32-make: *** [Makefile:135: all] Error 2
```

**Fix:**
This issue is resolved by adding the `primetab.cpp` to line 120 in `cryptopp/sources.cmake` file. 

**Primetab.cpp:** 
```
// primetab.cpp - written and placed in the public domain by Jeffrey Walton
//
// nbtheory.cpp originally built the prime table on the fly, and then
// returned a reference to it in a Singleton. This was useful to
// save memory in the old days. Nowadays we can precompute the table
// and place it in the read-only data segment. Also see
// https://github.com/weidai11/cryptopp/issues/1210.

// The table below was generated from the original Crypto++ table:
```


