### PR TITLE
build: detect and work around broken cmake_path

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1376,6 +1376,10 @@ target_compile_definitions(
         $<INSTALL_INTERFACE:CRYPTOPP_INCLUDE_PREFIX=${CRYPTOPP_INCLUDE_PREFIX}>
 )
 cmake_path(GET cryptopp_SOURCE_DIR PARENT_PATH CRYPTOPP_PREFIXED_INCLUDE_DIR)
+if (cryptopp_SOURCE_DIR STREQUAL CRYPTOPP_PREFIXED_INCLUDE_DIR)
+    # Work around a CMake bug when built using certain toolchains, where cmake_path returns the same path.
+    get_filename_component(CRYPTOPP_PREFIXED_INCLUDE_DIR "${cryptopp_SOURCE_DIR}" DIRECTORY)
+endif()
 target_include_directories(
     cryptopp
     PUBLIC


### PR DESCRIPTION
Hopefully an acceptable solution for https://github.com/abdes/cryptopp-cmake/issues/89

Detect when `cmake_path(GET ... PARENT_PATH ...)` of the CMake under use is broken (returns the same path), and falls back on `get_filename_component(... DIRECTORY)`.