### PR TITLE
Fix target detection for Windows ARM64EC

### DIFF
--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -10,8 +10,8 @@ set(archdetect_c_code
 /*
     ARM family, known revisions: V5, V6, V7, V8
 */
-#if defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(_M_ARM64) || defined(__aarch64__) || defined(__ARM64__)
-#  if defined(__aarch64__) || defined(__ARM64__) || defined(_M_ARM64)
+#if defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(__aarch64__) || defined(__ARM64__)
+#  if defined(__aarch64__) || defined(__ARM64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #    error cmake_ARCH arm64
 #  else
 #    error cmake_ARCH arm

--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -743,7 +743,7 @@ endif()
 # Aach32 and Aarch64               #####
 # ##############################################################################
 
-if(CRYPTOPP_ARMV8)
+if(CRYPTOPP_ARMV8 AND NOT MSVC)
     check_compile_link_option(
       "-DCRYPTOPP_ARM_NEON_HEADER=1"   CRYPTOPP_ARM_NEON_HEADER
       "${TEST_PROG_DIR}/test_arm_neon_header.cpp"


### PR DESCRIPTION
- Treat MSVC ARM64EC as an ARM64 target.
- Don't try setting various '-march' options for ARM64 on MSVC, where the switch does not apply.

With the accompanying changes in https://github.com/weidai11/cryptopp/pull/1257, this enables building CryptoPP for Windows ARM64EC with cryptopp-cmake.
