### PR TITLE
build: fix compiling for ARM with MSVC but not Visual Studio generator

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1241,7 +1241,7 @@ set_source_files_properties(
 # Compiler: MSVC
 # ------------------------------------------------------------------------------
 if(MSVC AND NOT CRYPTOPP_DISABLE_ASM)
-    if(${CMAKE_GENERATOR_PLATFORM} MATCHES "ARM")
+    if(${CMAKE_GENERATOR_PLATFORM} MATCHES "ARM" OR CRYPTOPP_ARM32 OR CRYPTOPP_ARMV8)
         message(
             STATUS
             "[cryptopp] Disabling ASM because ARM is specified as target platform."


### PR DESCRIPTION
When compiling for Windows ARM64 using the MSVC toolchain but a generator other than Visual Studio, the `${CMAKE_GENERATOR_PLATFORM} MATCHES "ARM"` check fails since `CMAKE_GENERATOR_PLATFORM = ARM` is only valid for the Visual Studio generator. As a result, the compile fails on `rdrand.asm`.

This fixes the issue by also checking the detected compile architecture with `CRYPTOPP_ARM32 OR CRYPTOPP_ARMV8`.