### PR TITLE
Update tests

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -15,7 +15,7 @@ jobs:
           {generator: "NMake Makefiles", os: windows-latest},
           {generator: "Visual Studio 16 2019", os: windows-2019}]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -89,7 +89,7 @@ jobs:
               omp: "ON",
             }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -175,7 +175,7 @@ jobs:
               generators: "Ninja",
             }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -272,7 +272,7 @@ jobs:
         shell: msys2 {0}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup MSYS2
@@ -328,7 +328,7 @@ jobs:
     name: Cygwin  ${{ matrix.config.name }}(${{ matrix.build-type }})
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Setup cygwin

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -30,7 +30,7 @@ jobs:
           version: 1.11.0
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.14
+        uses: jwlawson/actions-setup-cmake@v2.0.1
         with:
           cmake-version: 3.21.x
 
@@ -104,7 +104,7 @@ jobs:
           version: 1.11.0
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.14
+        uses: jwlawson/actions-setup-cmake@v2.0.1
         with:
           cmake-version: 3.21.x
 
@@ -190,7 +190,7 @@ jobs:
           version: 1.11.0
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.14
+        uses: jwlawson/actions-setup-cmake@v2.0.1
         with:
           cmake-version: 3.21.x
 


### PR DESCRIPTION
This should fix almost all warnings from the action regarding the outdated node version. Just the one from setup-ninja is left which I'm not sure if it's worth to open an issue and the xcode-select which has an open PR for this is left.