### PR TITLE
Remove pem_eol.cxx

### DIFF
--- a/cryptopp/sources.cmake
+++ b/cryptopp/sources.cmake
@@ -187,7 +187,6 @@ set(cryptopp_SOURCES
 
 set(cryptopp_SOURCES_PEM
     "${cryptopp-pem_SOURCE_DIR}/pem_common.cpp"
-    "${cryptopp-pem_SOURCE_DIR}/pem_eol.cxx"
     "${cryptopp-pem_SOURCE_DIR}/pem_read.cpp"
     "${cryptopp-pem_SOURCE_DIR}/pem_write.cpp"
     "${cryptopp-pem_SOURCE_DIR}/x509cert.cpp"


### PR DESCRIPTION
That file is not part of the actual library, but a utility used by the tests to convert end-of-line characters. 