### PR TITLE
Amending the Visual Studio generator + asm build workaround

### DIFF
--- a/cryptopp/CMakeLists.txt
+++ b/cryptopp/CMakeLists.txt
@@ -1256,7 +1256,7 @@ if(MSVC AND NOT CRYPTOPP_DISABLE_ASM)
         enable_language(ASM_MASM)
         if(NOT CRYPTOPP_DISABLE_RDRAND)
             list(APPEND cryptopp_SOURCES_ASM ${cryptopp_SOURCE_DIR}/rdrand.asm)
-            if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
+            if(${CMAKE_GENERATOR} MATCHES "Visual Studio.*" AND ${CMAKE_VERSION} VERSION_LESS "3.28")
                 # workaround https://github.com/abdes/cryptopp-cmake/issues/13
                 set_source_files_properties(
                     ${cryptopp_SOURCE_DIR}/rdrand.asm


### PR DESCRIPTION
This pull request amends the workaround fix made in https://github.com/abdes/cryptopp-cmake/pull/20. It seems that with CMake 28+ this is no longer an issue. I have not tested earlier versions of CMake but this comment https://github.com/abdes/cryptopp-cmake/issues/13#issuecomment-1231692123 reports seeing the issue with CMake version 3.23.1.

The reason for making this amendment is that the original workaround appears to prevent us from referring to `${TARGET_OBJECTS:cryptopp}` as below:

```
add_subdirectory(thirdparty/cryptopp-cmake)
add_library(mylib
    STATIC
        ${SOURCES}
        $<TARGET_OBJECTS:cryptopp>)
```

The linker is unable to find the asm object file:

```
LINK : fatal error LNK1181: cannot open input file 'D:\projects\libbcml\build\_deps\cryptopp-cmake-build\cryptopp\cryptopp.dir\Release\__\crypto++\rdrand.asm.obj'
```